### PR TITLE
added Rant class

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ __Include the class:__
 require 'vendor/autoload.php';
 ```
 
-- Including the file manually
+- Including the files manually
 ```php
 <?php
 include 'src/Connection.php';
+include 'src/Rant.php';
 ```
 
 Once included, you can initialise the class using either of the following:
@@ -32,14 +33,13 @@ $devRant = new Connection;
 
 Method Name           | Parameters | Returns
 --------------------- | ---------- | -------
-getRants()            | void       | `string (json)`
-getRantById($id)      | int        | `string (json)`
-getUserById($id)      | int        | `string (json)`
-searchRants($query)   | string     | `string (json)`
-getUsersId($username) | string     | `string (json)`
+getRants($searchterm) | string (optional) | `array of Rant objects`
+getRantById($id)      | int        | `Rant object`
+getUserById($id)      | int        | `array`
+getUsersId($username) | string     | `array`
 login($username, $password) | strings     | `boolean`
 logout()              | void       | `void`
-postNewRant($rant_content, $tags) | strings | `string (json)`
+rant($rant) | Rant object | `array`
 
 ## Examples
 
@@ -48,13 +48,13 @@ postNewRant($rant_content, $tags) | strings | `string (json)`
 $devRant = new \pxgamer\devRant\Connection;
 $devRant->getRants();
 ```
-Returns:
-```json
-{
-    "success": true,
-    "rants": [
-    ]
-}
+Returns false on failure, or:
+```php
+[
+    0 => Rant object,
+    1 => Rant object,
+    ...
+]
 ```
 
 ### _Getting a single rant by its id_
@@ -62,16 +62,7 @@ Returns:
 $devRant = new \pxgamer\devRant\Connection;
 $devRant->getRantById(int);
 ```
-Returns:
-```json
-{
-    "rant": {
-    },
-    "comments": [
-    ],
-    "success": true
-}
-```
+Returns false on failure, or a `Rant` object.
 
 ### _Getting a user by their id_
 ```php
@@ -79,82 +70,81 @@ $devRant = new \pxgamer\devRant\Connection;
 $devRant->getUserById(int);
 ```
 Returns:
-```json
-{
-    "success": true,
-    "profile": {
-        "username": "",
-        "score": 0,
-        "about": "",
-        "location": "",
-        "created_time": 1474613872,
-        "skills": "",
-        "github": "",
-        "website": "",
-        "content": {
-            "content": {
-                "rants": [],
-                "upvoted": [],
-                "comments": [],
-                "favorites": []
-            },
-            "counts": {}
-        },
-        "avatar": {}
-    }
-}
+```php
+[
+    "success" => true,
+    "profile" => [
+        "username" => "",
+        "score" => 0,
+        "about" => "",
+        "location" => "",
+        "created_time" => 1474613872,
+        "skills" => "",
+        "github" => "",
+        "website" => "",
+        "content" => [
+            "content" => [
+                "rants" => [],
+                "upvoted" => [],
+                "comments" => [],
+                "favorites" => []
+            [,
+            "counts" => []
+        ],
+        "avatar" => []
+    ]
+]
 ```
 
 ### _Search rants_
 ```php
 $devRant = new \pxgamer\devRant\Connection;
-$devRant->searchRants('string');
+$devRant->getRants('string');
 ```
-Returns:
-```json
-{
-    "success": true,
-    "results": [
-        {
-            "id": 0,
-            "text": "string",
-            "num_upvotes": 0,
-            "num_downvotes": 0,
-            "score": 0,
-            "created_time": 0,
-            "attached_image": {
-                "url": "string",
-                "width": 0,
-                "height": 0
-            },
-            "num_comments": 0,
-            "tags": [
-                "string"
-            ],
-            "vote_state": 0,
-            "edited": false,
-            "user_id": 0,
-            "user_username": "string",
-            "user_score": 0,
-            "user_avatar": {
-                "b": "string"
-            }
-        }
-    ]
-}
+Returns false on failure, or:
+```php
+[
+    0 => Rant object [
+        "id" => 0,
+        "text" => "string",
+        "num_upvotes" => 0,
+        "num_downvotes" => 0,
+        "score" => 0,
+        "created_time" => 0,
+        "attached_image" => [
+            "url" => "string",
+            "width" => 0,
+            "height" => 0
+        ],
+        "num_comments" => 0,
+        "tags" => [
+            "string"
+        ],
+        "vote_state" => 0,
+        "edited" => false,
+        "user_id" => 0,
+        "user_username" => "string",
+        "user_score" => 0,
+        "user_avatar" => [
+            "b" => "string"
+        ]
+    ],
+    1 => Rant object,
+    ...
+]
 ```
 
 ### _Getting a user's id from their username_
 ```php
 $devRant = new \pxgamer\devRant\Connection;
-$devRant->getUsersId('string');
+$devRant->getUserId('username');
 ```
 Returns:
-```json
-{
-    "success": true,
-    "user_id": 0
-}
+```php
+[
+    "success" => true,
+    "user_id" => 0
+]
 ```
 
 ### _Getting signed in_
@@ -166,15 +156,17 @@ Returns `true` if successful, `false` if not
 
 ### _Posting a rant_
 ```php
+use \pxgamer\devRant\Rant;
+
 $devRant = new \pxgamer\devRant\Connection;
 if ($devRant->login('username', 'password')) {
-    $devRant->postNewRant($rant_content, $tags);
+    $devRant->rant(new Rant($rant_content, $tags));
 }
 ```
 Returns:
-```json
-{
-    "success": true,
-    "rant_id": 31131
-}
+```php
+[
+    "success" => true,
+    "rant_id" => 31131
+]
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # devrant-php
 
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/PXgamer/devrant-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/PXgamer/devrant-php/?branch=master)
+
 A simple PHP wrapper for utilising the [devRant](https://devrant.io) api.
 
 ## Usage

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -124,14 +124,14 @@ class Connection
      */
     public function rant(Rant $rant)
     {
-        if ($this->tokenId === 0 || !is_string($rant_content)
-            || $rant->content === ''
+        if ($this->tokenId === 0 || !is_string($rant->text)
+            || $rant->text === ''
         ) {
             return false;
         }
 
         return $this->post('/devrant/rants', [
-            'rant' => $rant->content,
+            'rant' => $rant->text,
             'user_id' => $this->authUserId,
             'token_id' => $this->tokenId,
             'token_key' => $this->tokenKey,

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -24,9 +24,24 @@ class Connection
     /**
      * @return string
      */
-    public function getRants()
+    public function getRants($term = '')
     {
-        return $this->get('/devrant/rants');
+        $get = (empty($term))
+            ? '/devrant/rants'
+            : '/devrant/search?term=' . urlencode($term);
+
+        $data = $this->get($get);
+        if (!isset($data['success'])) {
+            return false;
+        }
+
+        $converter = function ($rant) {
+            return (new Rant())->populateFrom($rant);
+        };
+
+        return array_map($converter,
+            (empty($term)) ? $data['rants'] : $data['results']
+        );
     }
 
     /**
@@ -35,7 +50,15 @@ class Connection
      */
     public function getRantById($id)
     {
-        return (is_numeric($id)) ? $this->get('/devrant/rants/' . $id) : false;
+        if (!is_numeric($id)) {
+            return false;
+        }
+
+        $data = $this->get('/devrant/rants/' . $id);
+
+        return (isset($data['success']))
+            ? (new Rant())->populateFrom($data)
+            : false;
     }
 
     /**
@@ -45,15 +68,6 @@ class Connection
     public function getUserById($id)
     {
         return (is_numeric($id)) ? $this->get('/users/' . $id) : false;
-    }
-
-    /**
-     * @param $query
-     * @return string
-     */
-    public function searchRants($query)
-    {
-        return $this->get('/devrant/search?term=' . urlencode($query));
     }
 
     /**
@@ -108,20 +122,20 @@ class Connection
      * @param $tags
      * @return bool|string
      */
-    public function postNewRant($rant_content, $tags = '')
+    public function rant(Rant $rant)
     {
         if ($this->tokenId === 0 || !is_string($rant_content)
-            || $rant_content === ''
+            || $rant->content === ''
         ) {
             return false;
         }
 
         return $this->post('/devrant/rants', [
-            'rant' => $rant_content,
+            'rant' => $rant->content,
             'user_id' => $this->authUserId,
             'token_id' => $this->tokenId,
             'token_key' => $this->tokenKey,
-            'tags' => $tags,
+            'tags' => $rant->tags,
         ]);
     }
 
@@ -147,7 +161,7 @@ class Connection
         $result = curl_exec($ch);
         curl_close($ch);
 
-        return $result;
+        return json_decode($result, true);
     }
 
     /**
@@ -181,6 +195,6 @@ class Connection
         $result = curl_exec($ch);
         curl_close($ch);
 
-        return $result;
+        return json_decode($result, true);
     }
 }

--- a/src/Rant.php
+++ b/src/Rant.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace pxgamer\devRant;
+
+class Rant
+{
+    private $id;
+    private $text;
+    private $num_upvotes;
+    private $num_downvotes;
+    private $score;
+    private $created_time;
+    private $attached_image;
+    private $num_comments;
+    private $tags;
+    private $vote_state;
+    private $edited;
+    private $user_id;
+    private $user_username;
+    private $user_score;
+    private $user_avatar;
+
+    public function __construct($text = '', $tags = [])
+    {
+        $this->text = $text;
+        $this->tags = $tags;
+    }
+
+    public function __get($var)
+    {
+        return $this->$var;
+    }
+
+    public function populateFrom($rant)
+    {
+        unset($rant['success']);
+        array_walk($rant, function ($val, $key) {
+            $this->$key = $val;
+        });
+        return $this;
+    }
+}

--- a/tests/MainTest.php
+++ b/tests/MainTest.php
@@ -14,40 +14,35 @@ class MainTest extends PHPUnit_Framework_TestCase
     {
         $devRant = new Connection;
         $rants = $devRant->getRants();
-        $data = json_decode($rants, true);
-        $this->assertArrayHasKey('success', $data);
+        $this->assertNotFalse($rants);
     }
 
     public function testCanGetRantById()
     {
         $devRant = new Connection;
         $rantData = $devRant->getRantById(404);
-        $data = json_decode($rantData, true);
-        $this->assertArrayHasKey('success', $data);
+        $this->assertNotFalse($rantData);
     }
 
     public function testCanGetUserById()
     {
         $devRant = new Connection;
         $userData = $devRant->getUserById(404);
-        $data = json_decode($userData, true);
-        $this->assertArrayHasKey('success', $data);
+        $this->assertArrayHasKey('success', $userData);
     }
 
     public function testCanSearchRants()
     {
         $devRant = new Connection;
-        $searchData = $devRant->searchRants('Linux');
-        $data = json_decode($searchData, true);
-        $this->assertArrayHasKey('success', $data);
+        $searchData = $devRant->getRants('Linux');
+        $this->assertNotFalse($searchData);
     }
 
     public function testCanGetUserId()
     {
         $devRant = new Connection;
         $userIdData = $devRant->getUserId('pxgamer');
-        $data = json_decode($userIdData, true);
-        $this->assertArrayHasKey('success', $data);
+        $this->assertArrayHasKey('success', $userIdData);
     }
 
 }


### PR DESCRIPTION
This makes functions like `getRants()` return an array of Rant objects rather than the server's raw JSON in array form. Also, the function `postNewRant()` has been changed to `rant()` which now accepts one parameter, a Rant object, whose constructor takes two parameters: your rant text (string) and the tags that go with it (array of strings).